### PR TITLE
feat(lookback): accept bare integers and apply window to Inspector ECR

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,8 +22,9 @@ pub struct Cli {
     #[arg(long)]
     pub end_date: Option<String>,
 
-    /// Lookback window from today, e.g. 30d, 12w, 3m, 1y.
-    /// Accepted units: d / day / days, w / week / weeks, m / month / months, y / year / years.
+    /// Lookback window from today, e.g. 30, 30d, 12w, 3m, 1y.
+    /// A bare integer is treated as days. Accepted units: d / day / days,
+    /// w / week / weeks, m / month / months, y / year / years.
     /// Sets end-date to today and start-date to today minus the window.
     /// Cannot be combined with --start-date or --end-date.
     #[arg(long)]
@@ -204,13 +205,27 @@ pub struct Cli {
     pub sbom_format: String,
 }
 
-/// Parse a lookback string like "30d", "12weeks", "3m", "1year" into a start
-/// `NaiveDate` (end date is always today).
+/// Parse a lookback string like "30", "30d", "12weeks", "3m", "1year" into a
+/// start `NaiveDate` (end date is always today). A bare integer is treated
+/// as days, so `--lookback 30` is equivalent to `--lookback 30d`.
 pub fn parse_lookback(s: &str) -> Result<NaiveDate> {
     let s = s.trim().to_ascii_lowercase();
+    let today = chrono::Utc::now().date_naive();
+
+    // Bare integer → days. `--lookback 30` == `--lookback 30d`.
+    if !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()) {
+        let amount: i64 = s
+            .parse()
+            .context("--lookback: expected a positive integer")?;
+        if amount <= 0 {
+            anyhow::bail!("--lookback: amount must be greater than zero");
+        }
+        return Ok(today - chrono::Duration::days(amount));
+    }
+
     let split = s
         .find(|c: char| c.is_alphabetic())
-        .context("--lookback must start with a number, e.g. 30d or 3months")?;
+        .context("--lookback must start with a number, e.g. 30, 30d, or 3months")?;
     let amount: i64 = s[..split]
         .parse()
         .context("--lookback: expected a positive integer before the unit")?;
@@ -218,7 +233,6 @@ pub fn parse_lookback(s: &str) -> Result<NaiveDate> {
         anyhow::bail!("--lookback: amount must be greater than zero");
     }
     let unit = s[split..].trim_end_matches('s');
-    let today = chrono::Utc::now().date_naive();
     let start = match unit {
         "d" | "day" => today - chrono::Duration::days(amount),
         "w" | "week" => today - chrono::Duration::weeks(amount),

--- a/src/providers/aws/inspector_ecr/mod.rs
+++ b/src/providers/aws/inspector_ecr/mod.rs
@@ -5,8 +5,9 @@ use transforms::{
 
 use anyhow::Result;
 use async_trait::async_trait;
+use aws_sdk_inspector2::primitives::DateTime as InspectorDateTime;
 use aws_sdk_inspector2::types::{
-    FilterCriteria, SortCriteria, SortField, SortOrder, StringComparison, StringFilter,
+    DateFilter, FilterCriteria, SortCriteria, SortField, SortOrder, StringComparison, StringFilter,
 };
 use aws_sdk_inspector2::Client as Inspector2Client;
 
@@ -126,7 +127,6 @@ impl CsvCollector for InspectorEcrImagesCollector {
 
         const MAX_ROWS_PER_SEVERITY: usize = 10_000;
         const SEVERITY_LEVELS: [&str; 5] = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFORMATIONAL"];
-        let _ = dates;
 
         let mut rows = Vec::new();
 
@@ -146,11 +146,25 @@ impl CsvCollector for InspectorEcrImagesCollector {
                 .value("ACTIVE")
                 .build()
                 .expect("StringFilter is always valid");
-            let filter = FilterCriteria::builder()
+
+            let mut filter_builder = FilterCriteria::builder()
                 .resource_type(resource_filter)
                 .severity(severity_filter)
-                .finding_status(status_filter)
-                .build();
+                .finding_status(status_filter);
+
+            // !! DATE FILTER: MUST use first_observed_at — do NOT use last_observed_at or updated_at !!
+            // Inspector2 rescans continuously; last_observed_at/updated_at are stamped with today's
+            // date on every rescan and so return the full active set regardless of window.
+            // first_observed_at is set ONCE at finding creation and is the only reliable scoping field.
+            if let Some((start, end)) = dates {
+                filter_builder = filter_builder.first_observed_at(
+                    DateFilter::builder()
+                        .start_inclusive(InspectorDateTime::from_secs(start))
+                        .end_inclusive(InspectorDateTime::from_secs(end))
+                        .build(),
+                );
+            }
+            let filter = filter_builder.build();
 
             let mut next_token: Option<String> = None;
             let mut severity_count: usize = 0;


### PR DESCRIPTION
## Summary

- `--lookback` now accepts a bare integer as days (e.g. `--lookback 30` == `--lookback 30d`), in addition to the existing `d`/`w`/`m`/`y` units. `--help` documents the new form.
- The Inspector2 ECR Images collector previously discarded its `dates` parameter (`let _ = dates;`), so `--lookback` had no effect on ECR findings. It now attaches a `first_observed_at` `DateFilter` to the per-severity `FilterCriteria`, mirroring the pattern already used in `inspector.rs` and `inspector_history.rs`.
- Runner wiring (`CollectParams.start_time`/`end_time`, `inventory_dates`, and the guard rejecting `--lookback` combined with `--start-date`/`--end-date`) verified already in place; no runner changes were needed.

## Why `first_observed_at` and not `last_observed_at` / `updated_at`

Inspector2 rescans continuously and stamps `last_observed_at`/`updated_at` with today's date on every rescan for every active finding, so filtering on those fields returns the full active set regardless of the requested window. `first_observed_at` is written once at finding creation and is the only field that reliably scopes results to a date period. Same rule already enforced in `src/providers/aws/inspector.rs:190-208`.

## Files changed

- `src/cli.rs` — `parse_lookback` + `Cli.lookback` doc comment
- `src/providers/aws/inspector_ecr/mod.rs` — imports + per-severity `FilterCriteria` builder

## Test plan

- [x] `cargo check` clean, no new warnings
- [x] `cargo run -- --help` shows the updated `--lookback` description (mentions bare integers)
- [x] `cargo run -- --lookback 30 --start-date 2026-01-01 --end-date 2026-06-01` errors with `--lookback cannot be combined with --start-date or --end-date`
- [ ] End-to-end against a real AWS account: `cargo run -- --lookback 30 --collectors inspector-ecr --region us-east-1` returns findings whose `First Observed At` falls within the last 30 days